### PR TITLE
add spec for transactions and nested transactions

### DIFF
--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -242,4 +242,57 @@ describe Driver do
       File.delete(DB_FILENAME)
     end
   end
+
+  describe "transactions" do
+    it "can read inside transaction and rollback after" do
+      with_db do |db|
+        db.exec "create table person (name varchar(25))"
+        db.transaction do |tx|
+          tx.connection.scalar("select count(*) from person").should eq(0)
+          tx.connection.exec "insert into person (name) values (?)", "John Doe"
+          tx.connection.scalar("select count(*) from person").should eq(1)
+          tx.rollback
+        end
+        db.scalar("select count(*) from person").should eq(0)
+      end
+    end
+
+    it "can read inside transaction or after commit" do
+      with_db do |db|
+        db.exec "create table person (name varchar(25))"
+        db.transaction do |tx|
+          tx.connection.scalar("select count(*) from person").should eq(0)
+          tx.connection.exec "insert into person (name) values (?)", "John Doe"
+          tx.connection.scalar("select count(*) from person").should eq(1)
+          # using other connection
+          db.scalar("select count(*) from person").should eq(0)
+        end
+        db.scalar("select count(*) from person").should eq(1)
+      end
+    end
+  end
+
+  describe "nested transactions" do
+    it "can read inside transaction and rollback after" do
+      with_db do |db|
+        db.exec "create table person (name varchar(25))"
+        db.transaction do |tx_0|
+          tx_0.connection.scalar("select count(*) from person").should eq(0)
+          tx_0.connection.exec "insert into person (name) values (?)", "John Doe"
+          tx_0.transaction do |tx_1|
+            tx_1.connection.exec "insert into person (name) values (?)", "Sarah"
+            tx_1.connection.scalar("select count(*) from person").should eq(2)
+            tx_1.transaction do |tx_2|
+              tx_2.connection.exec "insert into person (name) values (?)", "Jimmy"
+              tx_2.connection.scalar("select count(*) from person").should eq(3)
+              tx_2.rollback
+            end
+          end
+          tx_0.connection.scalar("select count(*) from person").should eq(2)
+          tx_0.rollback
+        end
+        db.scalar("select count(*) from person").should eq(0)
+      end
+    end
+  end
 end

--- a/src/sqlite3/connection.cr
+++ b/src/sqlite3/connection.cr
@@ -33,6 +33,36 @@ class SQLite3::Connection < DB::Connection
     LibSQLite3.close_v2(self)
   end
 
+  # :nodoc:
+  def perform_begin_transaction
+    self.prepared.exec "BEGIN"
+  end
+
+  # :nodoc:
+  def perform_commit_transaction
+    self.prepared.exec "COMMIT"
+  end
+
+  # :nodoc:
+  def perform_rollback_transaction
+    self.prepared.exec "ROLLBACK"
+  end
+
+  # :nodoc:
+  def perform_create_savepoint(name)
+    self.prepared.exec "SAVEPOINT #{name}"
+  end
+
+  # :nodoc:
+  def perform_release_savepoint(name)
+    self.prepared.exec "RELEASE SAVEPOINT #{name}"
+  end
+
+  # :nodoc:
+  def perform_rollback_savepoint(name)
+    self.prepared.exec "ROLLBACK TO #{name}"
+  end
+
   # Dump the database to another SQLite3 database. This can be used for backing up a SQLite3 Database
   # to disk or the opposite
   def dump(to : SQLite3::Connection)


### PR DESCRIPTION
Add specs that ensures https://github.com/crystal-lang/crystal-db/pull/27 works in sqlite
Override transactions statements to be executed in a prepared fashion since sqlite does not support unprepared statements.