### PR TITLE
Make SQLite3::Connection#dump copy all DB pages

### DIFF
--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -44,4 +44,17 @@ describe Connection do
       end
     end
   end
+
+  it "opens a database, inserts records (>1024K), and dumps to an in-memory db" do
+    with_db do |db|
+      with_mem_db do |in_memory_db|
+        db.exec "create table person (name string, age integer)"
+        db.transaction do |tx|
+          100_000.times { tx.connection.exec "insert into person values (\"foo\", 10)" }
+        end
+        dump db, in_memory_db
+        in_memory_db.scalar("select count(*) from person").should eq(100_000)
+      end
+    end
+  end
 end

--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -20,7 +20,7 @@ lib LibSQLite3
   fun errmsg = sqlite3_errmsg(SQLite3) : UInt8*
 
   fun backup_init = sqlite3_backup_init(SQLite3, UInt8*, SQLite3, UInt8*) : SQLite3Backup
-  fun backup_step = sqlite3_backup_step(SQLite3Backup, Int8) : Code
+  fun backup_step = sqlite3_backup_step(SQLite3Backup, Int32) : Code
   fun backup_finish = sqlite3_backup_finish(SQLite3Backup) : Code
 
   fun prepare_v2 = sqlite3_prepare_v2(db : SQLite3, zSql : UInt8*, nByte : Int32, ppStmt : Statement*, pzTail : UInt8**) : Int32


### PR DESCRIPTION
dump() was only ever copying one page (typically 1024k). Now it copies
all of them. Fixes issue #15.