### PR TITLE
CI: Add CircleCI using manastech/crystal@1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+orbs:
+  crystal: manastech/crystal@1.0
+
+commands:
+  install-sqlite:
+    steps:
+      - run:
+          name: Install `sqlite`
+          command: apt-get update && apt-get install -y libsqlite3-dev
+
+jobs:
+  test:
+    parameters:
+      executor:
+        type: executor
+        default: crystal/default
+    executor: << parameters.executor >>
+    steps:
+      - install-sqlite
+      - crystal/version
+      - checkout
+      - crystal/with-shards-cache:
+          steps:
+            - crystal/shards-install
+      - crystal/spec
+      - crystal/format-check
+
+executors:
+  nightly:
+    docker:
+      - image: 'crystallang/crystal:nightly'
+    environment:
+      SHARDS_OPTS: --ignore-crystal-version
+
+workflows:
+  version: 2
+
+  build:
+    jobs:
+      - test
+      - test:
+          name: test-on-nightly
+          executor:
+            name: nightly
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test:
+          name: test-on-nightly
+          executor:
+            name: nightly
+


### PR DESCRIPTION
This shard was used to test the circleci orb.
It's better to commit this configuration to master so the status checks are happy.

Also, it follows the guidance to check the shard will be working for 1.0