### PR TITLE
Fix result set & connection release lifecycle

### DIFF
--- a/src/sqlite3/result_set.cr
+++ b/src/sqlite3/result_set.cr
@@ -2,8 +2,8 @@ class SQLite3::ResultSet < DB::ResultSet
   @column_index = 0
 
   protected def do_close
-    super
     LibSQLite3.reset(self)
+    super
   end
 
   # Advances to the next row. Returns `true` if there's a next row,


### PR DESCRIPTION
While working on #87 we noticed that the result set should be released before release the connection.

This wasn't noticed before because connections are usually put back in the pool to be reused.