### PR TITLE
add arg support for Int16, Int8, UInt16, UInt8

### DIFF
--- a/src/sqlite3/result_set.cr
+++ b/src/sqlite3/result_set.cr
@@ -51,6 +51,30 @@ class SQLite3::ResultSet < DB::ResultSet
     @column_index
   end
 
+  def read(t : UInt8.class) : UInt8
+    read(Int64).to_u8
+  end
+
+  def read(type : UInt8?.class) : UInt8?
+    read(Int64?).try &.to_u8
+  end
+
+  def read(t : UInt16.class) : UInt16
+    read(Int64).to_u16
+  end
+
+  def read(type : UInt16?.class) : UInt16?
+    read(Int64?).try &.to_u16
+  end
+
+  def read(t : UInt32.class) : UInt32
+    read(Int64).to_u32
+  end
+
+  def read(type : UInt32?.class) : UInt32?
+    read(Int64?).try &.to_u32
+  end
+
   def read(t : Int8.class) : Int8
     read(Int64).to_i8
   end

--- a/src/sqlite3/result_set.cr
+++ b/src/sqlite3/result_set.cr
@@ -51,6 +51,22 @@ class SQLite3::ResultSet < DB::ResultSet
     @column_index
   end
 
+  def read(t : Int8.class) : Int8
+    read(Int64).to_i8
+  end
+
+  def read(type : Int8?.class) : Int8?
+    read(Int64?).try &.to_i8
+  end
+
+  def read(t : Int16.class) : Int16
+    read(Int64).to_i16
+  end
+
+  def read(type : Int16?.class) : Int16?
+    read(Int64?).try &.to_i16
+  end
+
   def read(t : Int32.class) : Int32
     read(Int64).to_i32
   end

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -45,6 +45,18 @@ class SQLite3::Statement < DB::Statement
     check LibSQLite3.bind_int(self, index, value ? 1 : 0)
   end
 
+  private def bind_arg(index, value : UInt8)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
+  private def bind_arg(index, value : UInt16)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
+  private def bind_arg(index, value : UInt32)
+    check LibSQLite3.bind_int(self, index, value)
+  end
+
   private def bind_arg(index, value : Int8)
     check LibSQLite3.bind_int(self, index, value.to_i)
   end

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -54,7 +54,7 @@ class SQLite3::Statement < DB::Statement
   end
 
   private def bind_arg(index, value : UInt32)
-    check LibSQLite3.bind_int(self, index, value)
+    check LibSQLite3.bind_int64(self, index, value.to_i64)
   end
 
   private def bind_arg(index, value : Int8)

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -45,6 +45,22 @@ class SQLite3::Statement < DB::Statement
     check LibSQLite3.bind_int(self, index, value ? 1 : 0)
   end
 
+  private def bind_arg(index, value : UInt8)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
+  private def bind_arg(index, value : UInt16)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
+  private def bind_arg(index, value : Int8)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
+  private def bind_arg(index, value : Int16)
+    check LibSQLite3.bind_int(self, index, value.to_i)
+  end
+
   private def bind_arg(index, value : Int32)
     check LibSQLite3.bind_int(self, index, value)
   end

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -45,14 +45,6 @@ class SQLite3::Statement < DB::Statement
     check LibSQLite3.bind_int(self, index, value ? 1 : 0)
   end
 
-  private def bind_arg(index, value : UInt8)
-    check LibSQLite3.bind_int(self, index, value.to_i)
-  end
-
-  private def bind_arg(index, value : UInt16)
-    check LibSQLite3.bind_int(self, index, value.to_i)
-  end
-
   private def bind_arg(index, value : Int8)
     check LibSQLite3.bind_int(self, index, value.to_i)
   end


### PR DESCRIPTION
I was trying to use Jennifer with sqlite with an Int16 in my model, and I got an error saying that it was supported. Upon looking into it, it seems that sqlite only stores regular Int32s (and it works if I switch the type to Int32). However, given that Int8, Int16, UInt8, and UInt16 can all fit in a Int32. I don't see why we can't just convert them to Int32's. There is already a similar thing happening for Float32 being converted to Float64, and this is essentially the same thing but for ints.

I didn't see any tests for any of the other binds, so I didn't add any here.