### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/src/sqlite3/result_set.cr
+++ b/src/sqlite3/result_set.cr
@@ -155,7 +155,7 @@ class SQLite3::ResultSet < DB::ResultSet
     @statement.as(Statement)
   end
 
-  private def moving_column
+  private def moving_column(&)
     res = yield @column_index
     @column_index += 1
     res


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.