### PR TITLE
Use URI#hostname to avoid interpreting :memory: as [:memory:]

### DIFF
--- a/src/sqlite3/connection.cr
+++ b/src/sqlite3/connection.cr
@@ -12,7 +12,7 @@ class SQLite3::Connection < DB::Connection
       params = HTTP::Params.parse(uri.query || "")
 
       Options.new(
-        filename: URI.decode_www_form((uri.host || "") + uri.path),
+        filename: URI.decode_www_form((uri.hostname || "") + uri.path),
         # pragmas
         busy_timeout: params.fetch("busy_timeout", default.busy_timeout),
         cache_size: params.fetch("cache_size", default.cache_size),
@@ -56,7 +56,7 @@ class SQLite3::Connection < DB::Connection
   end
 
   def self.filename(uri : URI)
-    URI.decode_www_form((uri.host || "") + uri.path)
+    URI.decode_www_form((uri.hostname || "") + uri.path)
   end
 
   def build_prepared_statement(query) : Statement


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/pull/16164#issuecomment-3397579056

This change is compatible with prior crystal versions but also with crystal 1.18+ due to the above mentioned change.

A bit unfortunate that we can't go back in time and advertise the upper bound of crystal versions in previous crystal-sqlite3 packages...