### PR TITLE
Add DLL name to `@[Link]` annotation

### DIFF
--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -1,6 +1,6 @@
 require "./type"
 
-@[Link("sqlite3")]
+@[Link("sqlite3", dll: "sqlite3.dll")]
 lib LibSQLite3
   type SQLite3 = Void*
   type Statement = Void*

--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -1,6 +1,9 @@
 require "./type"
 
-@[Link("sqlite3", dll: "sqlite3.dll")]
+@[Link("sqlite3")]
+{% if flag?(:msvc) %}
+  @[Link(dll: "sqlite3.dll")]
+{% end %}
 lib LibSQLite3
   type SQLite3 = Void*
   type Statement = Void*


### PR DESCRIPTION
This is required on MSVC to copy the correct DLL to the output directory.

This assumes the DLL is the official [`sqlite-dll-win-x64-*.zip`](https://sqlite.org/download.html) download.