### PR TITLE
Prevent arguments from being GC'd before statement is executed

### DIFF
--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -101,8 +101,8 @@ lib LibSQLite3
 
   fun bind_int = sqlite3_bind_int(stmt : Statement, idx : Int32, value : Int32) : Int32
   fun bind_int64 = sqlite3_bind_int64(stmt : Statement, idx : Int32, value : Int64) : Int32
-  fun bind_text = sqlite3_bind_text(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Int64) : Int32
-  fun bind_blob = sqlite3_bind_blob(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Int64) : Int32
+  fun bind_text = sqlite3_bind_text(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Void* ->) : Int32
+  fun bind_blob = sqlite3_bind_blob(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Void* ->) : Int32
   fun bind_null = sqlite3_bind_null(stmt : Statement, idx : Int32) : Int32
   fun bind_double = sqlite3_bind_double(stmt : Statement, idx : Int32, value : Float64) : Int32
 

--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -101,8 +101,8 @@ lib LibSQLite3
 
   fun bind_int = sqlite3_bind_int(stmt : Statement, idx : Int32, value : Int32) : Int32
   fun bind_int64 = sqlite3_bind_int64(stmt : Statement, idx : Int32, value : Int64) : Int32
-  fun bind_text = sqlite3_bind_text(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Void* ->) : Int32
-  fun bind_blob = sqlite3_bind_blob(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Void* ->) : Int32
+  fun bind_text = sqlite3_bind_text(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Int64) : Int32
+  fun bind_blob = sqlite3_bind_blob(stmt : Statement, idx : Int32, value : UInt8*, bytes : Int32, destructor : Int64) : Int32
   fun bind_null = sqlite3_bind_null(stmt : Statement, idx : Int32) : Int32
   fun bind_double = sqlite3_bind_double(stmt : Statement, idx : Int32, value : Float64) : Int32
 

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -4,7 +4,16 @@ class SQLite3::Statement < DB::Statement
   # initialized to help with memory footprint.
   # See https://github.com/crystal-lang/crystal-sqlite3/pull/111 for more
   # context.
-  @_gc_safe_args : Array(Pointer(Void)) | Nil
+  @arg_refs : Array(Pointer(UInt8)) | Nil
+
+  private def clear_arg_refs
+    @arg_refs.try(&.clear)
+  end
+
+  private def track_arg_ref(ref)
+    arg_refs = @arg_refs ||= [] of Pointer(UInt8)
+    arg_refs.push(ref.to_unsafe)
+  end
 
   def initialize(connection, command)
     super(connection, command)
@@ -12,7 +21,7 @@ class SQLite3::Statement < DB::Statement
   end
 
   protected def perform_query(args : Enumerable) : DB::ResultSet
-    @_gc_safe_args.try(&.clear)
+    clear_arg_refs
     LibSQLite3.reset(self)
     args.each_with_index(1) do |arg, index|
       bind_arg(index, arg)
@@ -21,7 +30,7 @@ class SQLite3::Statement < DB::Statement
   end
 
   protected def perform_exec(args : Enumerable) : DB::ExecResult
-    @_gc_safe_args.try(&.clear)
+    clear_arg_refs
     LibSQLite3.reset(self.to_unsafe)
     args.each_with_index(1) do |arg, index|
       bind_arg(index, arg)
@@ -43,6 +52,7 @@ class SQLite3::Statement < DB::Statement
 
   protected def do_close
     super
+    clear_arg_refs
     check LibSQLite3.finalize(self)
   end
 
@@ -91,14 +101,12 @@ class SQLite3::Statement < DB::Statement
   end
 
   private def bind_arg(index, value : String)
-    @_gc_safe_args ||= [] of Pointer(Void)
-    @_gc_safe_args.try(&.push(pointerof(value).as(Pointer(Void))))
+    track_arg_ref(value)
     check LibSQLite3.bind_text(self, index, value, value.bytesize, nil)
   end
 
   private def bind_arg(index, value : Bytes)
-    @_gc_safe_args ||= [] of Pointer(Void)
-    @_gc_safe_args.try(&.push(pointerof(value).as(Pointer(Void))))
+    track_arg_ref(value)
     check LibSQLite3.bind_blob(self, index, value, value.size, nil)
   end
 

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -1,10 +1,18 @@
 class SQLite3::Statement < DB::Statement
+  # Keep references to bound strings and bytes to prevent them from being
+  # garbage collected before SQLite executes the statement. It is lazy
+  # initialized to help with memory footprint.
+  # See https://github.com/crystal-lang/crystal-sqlite3/pull/111 for more
+  # context.
+  @_gc_safe_args : Array(Pointer(Void)) | Nil
+
   def initialize(connection, command)
     super(connection, command)
     check LibSQLite3.prepare_v2(sqlite3_connection, command, command.bytesize + 1, out @stmt, nil)
   end
 
   protected def perform_query(args : Enumerable) : DB::ResultSet
+    @_gc_safe_args.try(&.clear)
     LibSQLite3.reset(self)
     args.each_with_index(1) do |arg, index|
       bind_arg(index, arg)
@@ -13,6 +21,7 @@ class SQLite3::Statement < DB::Statement
   end
 
   protected def perform_exec(args : Enumerable) : DB::ExecResult
+    @_gc_safe_args.try(&.clear)
     LibSQLite3.reset(self.to_unsafe)
     args.each_with_index(1) do |arg, index|
       bind_arg(index, arg)
@@ -82,11 +91,15 @@ class SQLite3::Statement < DB::Statement
   end
 
   private def bind_arg(index, value : String)
-    check LibSQLite3.bind_text(self, index, value, value.bytesize, -1) # -1 is SQLITE_TRANSIENT
+    @_gc_safe_args ||= [] of Pointer(Void)
+    @_gc_safe_args.try(&.push(pointerof(value).as(Pointer(Void))))
+    check LibSQLite3.bind_text(self, index, value, value.bytesize, nil)
   end
 
   private def bind_arg(index, value : Bytes)
-    check LibSQLite3.bind_blob(self, index, value, value.size, -1) # -1 is SQLITE_TRANSIENT
+    @_gc_safe_args ||= [] of Pointer(Void)
+    @_gc_safe_args.try(&.push(pointerof(value).as(Pointer(Void))))
+    check LibSQLite3.bind_blob(self, index, value, value.size, nil)
   end
 
   private def bind_arg(index, value : Time)

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -82,11 +82,11 @@ class SQLite3::Statement < DB::Statement
   end
 
   private def bind_arg(index, value : String)
-    check LibSQLite3.bind_text(self, index, value, value.bytesize, nil)
+    check LibSQLite3.bind_text(self, index, value, value.bytesize, -1) # -1 is SQLITE_TRANSIENT
   end
 
   private def bind_arg(index, value : Bytes)
-    check LibSQLite3.bind_blob(self, index, value, value.size, nil)
+    check LibSQLite3.bind_blob(self, index, value, value.size, -1) # -1 is SQLITE_TRANSIENT
   end
 
   private def bind_arg(index, value : Time)


### PR DESCRIPTION
This was a doozy of a bug to chase down. What was happening for me, was a query would occasionally return notably fewer results than expected.

What I believe was happening, was bound arguments were being garbage collected mid-query, resulting in the conditions changing while the query was executing and thus hitting the "DONE" condition in `step` earlier than it should have. My understanding is that when [`nil` is passed here](https://github.com/crystal-lang/crystal-sqlite3/blob/master/src/sqlite3/statement.cr#L85), that equates to `SQLITE_STATIC` ([see here](https://sqlite.org/c3ref/c_static.html)), ultimately deferring to the hosts memory management.

This PR changes the default behavior to use `SQLITE_TRANSIENT`, so that SQLite manages it's own copy of bound text and blob arguments.

This PR does change the signature of `sqlite3_bind_text` and `sqlite3_bind_blob`, largely because I didn't know how to get type casting to work nicely... I would far prefer to keep the signature, so if it is obvious to you, please holler!

Alternately - I was able to trick the GC into playing nice with the following (though I believe this PR is a better solution):

```crystal
class SQLite3::Statement
  # Keep references to bound strings and bytes to prevent them from
  # being garbage collected before SQLite executes the statement.
  @_gc_safe_strings = [] of String | Bytes

  protected def perform_query(args : Enumerable) : DB::ResultSet
    @_gc_safe_strings.clear
    previous_def
  end

  protected def perform_exec(args : Enumerable) : DB::ExecResult
    @_gc_safe_strings.clear
    previous_def
  end

  private def bind_arg(index, value : String)
    @_gc_safe_strings << value
    previous_def
  end

  private def bind_arg(index, value : Bytes)
    @_gc_safe_strings << value
    previous_def
  end
end
```