### PR TITLE
Do not check error code of `LibSQLite3.finalize`

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -149,4 +149,11 @@ DB::DriverSpecs(SQLite3::Any).run do |ctx|
     (db.scalar "select 'unmatching text' REGEXP '^m'").should eq 0
     (db.scalar "select 'matching text' REGEXP '^m'").should eq 1
   end
+
+  it "does not re-raise the last error on db.close" do |db|
+    db.exec "create table t (id integer primary key)"
+    expect_raises SQLite3::Exception, "UNIQUE constraint failed: t.id" do
+      db.exec %(insert into t values (1), (1))
+    end
+  end
 end

--- a/src/sqlite3/statement.cr
+++ b/src/sqlite3/statement.cr
@@ -53,7 +53,7 @@ class SQLite3::Statement < DB::Statement
   protected def do_close
     super
     clear_arg_refs
-    check LibSQLite3.finalize(self)
+    LibSQLite3.finalize(self)
   end
 
   private def bind_arg(index, value : Nil)


### PR DESCRIPTION
...as this function does *not* return memory-related errors, but instead, according to https://sqlite.org/c3ref/finalize.html:

> If the most recent evaluation of statement S failed, then sqlite3_finalize(S) returns the appropriate error code or extended error code.

Fixes #52

This has already been identified by @bcardiff. I assume the bug rarely shows up because most applications have a lot more successful statement executions than errorneous ones, and thus the chance for errors at shutdown is low.

---

For reference, this is how the other projects do it:

- MySQL: Does not have any closing logic https://github.com/crystal-lang/crystal-mysql/blob/a389494e3cd57c932ef0f19eb030c058f6e50b45/src/mysql/statement.cr
- PG: Does not have any closing logic https://github.com/will/crystal-pg/blob/9ce74e0c72b93a7c4ceca8b2f6fee00038108c74/src/pg/statement.cr
- ODBC: Also has a `check` around it:
  https://github.com/naqvis/crystal-odbc/blob/b874de2ce9194f5c69ca42dff254fea3464d4eb6/src/odbc/statement.cr#L36
  ```crystal
    # Free the statement handle
    check LibODBC.sql_free_handle(LibODBC::SQL_HANDLE_STMT, @stmt_handle)
    @stmt_handle = LibODBC::Sqlhandle.null
  ```
  However, according to the docs https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlfreehandle-function?view=sql-server-ver17, the error code actually *means* that the freeing process failed:
  > When SQLFreeHandle returns SQL_ERROR, an associated SQLSTATE value may be obtained from the diagnostic data structure for the handle that SQLFreeHandle tried to free but could not.
- Cassandra: Does not check for errors:
  https://github.com/kaukas/crystal-cassandra/blob/01a4f535a03fa40f6e9b1a28eebf0a8cef44adc2/src/cassandra/dbapi/statement.cr#L28
  ```crystal
  LibCass.statement_free(@cass_statement)
  super
  ```
- DuckDB: Does not check either:
  https://github.com/amauryt/crystal-duckdb/blob/1adee51d719b78fae0fe7cfd28ba66cf5062c133/src/duckdb/statement.cr#L23
  ```crystal
  LibDuckDB.destroy_prepare(pointerof(@statement))
  ```
- TDS: Simply ignores them:
  https://github.com/wonderix/crystal-tds/blob/0eb0bfe95f69a2ede5120612f0c957f5facce116/src/tds/prepared_statement.cr#L32
  ```crystal
  rescue ex : DB::Error
      # ignore errors when unpreparing to not affect the connection being closed
  end
   ```
